### PR TITLE
Implement user-level thread

### DIFF
--- a/07-Threads/Makefile
+++ b/07-Threads/Makefile
@@ -1,0 +1,24 @@
+CROSS_COMPILE ?= arm-none-eabi-
+CC := $(CROSS_COMPILE)gcc
+AS := $(CROSS_COMPILE)as
+CFLAGS = -fno-common -ffreestanding -O0 \
+	 -gdwarf-2 -g3 -Wall -Werror \
+	 -mcpu=cortex-m3 -mthumb \
+	 -Wl,-Tos.ld -nostartfiles \
+
+TARGET = os.bin
+all: $(TARGET)
+
+$(TARGET): os.c startup.c malloc.c threads.c
+	$(CC) $(CFLAGS) $^ -o os.elf
+	$(CROSS_COMPILE)objcopy -Obinary os.elf os.bin
+	$(CROSS_COMPILE)objdump -S os.elf > os.list
+
+qemu: $(TARGET)
+	@qemu-system-arm -M ? | grep stm32-p103 >/dev/null || exit
+	@echo "Press Ctrl-A and then X to exit QEMU"
+	@echo
+	qemu-system-arm -M stm32-p103 -nographic -kernel os.bin
+
+clean:
+	rm -f *.o *.elf *.bin *.list

--- a/07-Threads/malloc.c
+++ b/07-Threads/malloc.c
@@ -1,0 +1,100 @@
+#include <stddef.h>
+#include "malloc.h"
+#include "os.h"
+
+typedef long Align;
+
+union header {
+	struct {
+		union header *ptr;
+		unsigned int size;
+	} s;
+	Align x;
+};
+
+typedef union header Header;
+
+static unsigned char heaps[MAX_HEAPS];
+static unsigned char *program_break = heaps;
+
+static Header base; /* empty list to get started */
+static Header *freep = NULL; /* start of free list */
+
+static void *sbrk(unsigned int nbytes)
+{
+	if (program_break + nbytes >= heaps
+	    && program_break + nbytes < heaps + MAX_HEAPS) {
+		unsigned char *previous_pb = program_break;
+		program_break += nbytes;
+		return (void *)previous_pb;
+	} else {
+		return (void *) - 1;
+	}
+}
+
+void *malloc(unsigned int nbytes)
+{
+	Header *p, *prevp;
+	unsigned int nunits;
+	void *cp;
+
+	nunits = (nbytes + sizeof(Header) - 1) / sizeof(Header) + 1;
+
+	if ((prevp = freep) == NULL) {
+		base.s.ptr = freep = prevp = &base;
+		base.s.size = 0;
+	}
+
+	for (p = prevp->s.ptr; ; prevp = p, p = p->s.ptr) {
+		if (p->s.size >= nunits) {
+			if (p->s.size == nunits) {
+				prevp->s.ptr = p->s.ptr;
+			} else {
+				p->s.size -= nunits;
+				p += p->s.size;
+				p->s.size = nunits;
+			}
+			freep = prevp;
+			return (void *)(p + 1);
+		}
+
+		if (p == freep) {
+			cp = sbrk(nunits * sizeof(Header));
+			if (cp == (void *) - 1) {
+				return NULL;
+			} else {
+				p = (Header *)cp;
+				p->s.size = nunits;
+				free((void *)(p + 1));
+				p = freep;
+			}
+		}
+	}
+}
+
+void free(void *ap)
+{
+	Header *bp, *p;
+	bp = (Header *)ap - 1;
+
+	for (p = freep; !(bp > p && bp < p->s.ptr); p = p->s.ptr) {
+		if (p >= p->s.ptr && (bp > p || bp < p->s.ptr))
+			break;
+	}
+
+	if (bp + bp->s.size == p->s.ptr) {
+		bp->s.size += p->s.ptr->s.size;
+		bp->s.ptr = p->s.ptr->s.ptr;
+	} else {
+		bp->s.ptr = p->s.ptr;
+	}
+
+	if (p + p->s.size == bp) {
+		p->s.size += bp->s.size;
+		p->s.ptr = bp->s.ptr;
+	} else {
+		p->s.ptr = bp;
+	}
+
+	freep = p;
+}

--- a/07-Threads/malloc.h
+++ b/07-Threads/malloc.h
@@ -1,0 +1,8 @@
+#ifndef __MALLOC_H_
+#define __MALLOC_H_
+
+void *malloc(unsigned int nbytes);
+void free(void *ap);
+
+#endif
+

--- a/07-Threads/os.c
+++ b/07-Threads/os.c
@@ -1,0 +1,85 @@
+#include <stddef.h>
+#include <stdint.h>
+#include "reg.h"
+#include "threads.h"
+
+/* USART TXE Flag
+ * This flag is cleared when data is written to USARTx_DR and
+ * set when that data is transferred to the TDR
+ */
+#define USART_FLAG_TXE	((uint16_t) 0x0080)
+
+void usart_init(void)
+{
+	*(RCC_APB2ENR) |= (uint32_t)(0x00000001 | 0x00000004);
+	*(RCC_APB1ENR) |= (uint32_t)(0x00020000);
+
+	/* USART2 Configuration, Rx->PA3, Tx->PA2 */
+	*(GPIOA_CRL) = 0x00004B00;
+	*(GPIOA_CRH) = 0x44444444;
+	*(GPIOA_ODR) = 0x00000000;
+	*(GPIOA_BSRR) = 0x00000000;
+	*(GPIOA_BRR) = 0x00000000;
+
+	*(USART2_CR1) = 0x0000000C;
+	*(USART2_CR2) = 0x00000000;
+	*(USART2_CR3) = 0x00000000;
+	*(USART2_CR1) |= 0x2000;
+}
+
+void print_str(const char *str)
+{
+	while (*str) {
+		while (!(*(USART2_SR) & USART_FLAG_TXE));
+		*(USART2_DR) = (*str & 0xFF);
+		str++;
+	}
+}
+
+static void delay(int count)
+{
+	count *= 50000;
+	while (count--);
+}
+
+static void busy_loop(void *str)
+{
+	while (1) {
+		print_str(str);
+		print_str(": Running...\n");
+		delay(1000);
+	}
+}
+
+void test1(void *userdata)
+{
+	busy_loop(userdata);
+}
+
+void test2(void *userdata)
+{
+	busy_loop(userdata);
+}
+
+int main(void)
+{
+	const char *str1 = "Task1";
+	const char *str2 = "Task2";
+
+	usart_init();
+
+	if (thread_create(test1, (void *) str1) == -1)
+		print_str("Thread 1 creation failed\r\n");
+
+	if (thread_create(test2, (void *) str2) == -1)
+		print_str("Thread 2 creation failed\r\n");
+
+	/* SysTick configuration */
+	*SYSTICK_LOAD = 7200000;
+	*SYSTICK_VAL = 0;
+	*SYSTICK_CTRL = 0x07;
+
+	thread_start();
+
+	return 0;
+}

--- a/07-Threads/os.h
+++ b/07-Threads/os.h
@@ -1,0 +1,8 @@
+#ifndef __OS_H_
+#define __OS_H_
+
+#define MAX_TASKS 10
+#define STACK_SIZE 256
+#define MAX_HEAPS 4096
+
+#endif

--- a/07-Threads/os.ld
+++ b/07-Threads/os.ld
@@ -1,0 +1,38 @@
+ENTRY(reset_handler)
+
+MEMORY
+{
+	FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 128K
+	RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 40K
+}
+
+SECTIONS
+{
+	.text :
+	{
+		KEEP(*(.isr_vector))
+		*(.text)
+		*(.text.*)
+		*(.rodata)
+		_sromdev = .;
+		_eromdev = .;
+		_sidata = .;
+	} >FLASH
+
+	.data : AT(_sidata)
+	{
+		_sdata = .;
+		*(.data)
+		*(.data*)
+		_edata = .;
+	} >RAM
+
+	.bss :
+	{
+		_sbss = .;
+		*(.bss)
+		_ebss = .;
+	} >RAM
+
+	_estack = ORIGIN(RAM) + LENGTH(RAM);
+}

--- a/07-Threads/reg.h
+++ b/07-Threads/reg.h
@@ -1,0 +1,56 @@
+#ifndef __REG_H_
+#define __REG_H_
+
+#define __REG_TYPE	volatile uint32_t
+#define __REG		__REG_TYPE *
+
+#define SCS_BASE                        (uint32_t) (0xE000E000)
+#define SCB_BASE                        (SCS_BASE + 0x0D00)
+#define SCB_ICSR                        (volatile uint32_t *) (SCB_BASE + 0x004)
+#define SCB_ICSR_PENDSVSET              (uint32_t) (1 << 28)
+
+/* RCC Memory Map */
+#define RCC		((__REG_TYPE) 0x40021000)
+#define RCC_CR		((__REG) (RCC + 0x00))
+#define RCC_CFGR	((__REG) (RCC + 0x04))
+#define RCC_CIR		((__REG) (RCC + 0x08))
+#define RCC_APB2RSTR	((__REG) (RCC + 0x0C))
+#define RCC_APB1RSTR	((__REG) (RCC + 0x10))
+#define RCC_AHBENR	((__REG) (RCC + 0x14))
+#define RCC_APB2ENR	((__REG) (RCC + 0x18))
+#define RCC_APB1ENR	((__REG) (RCC + 0x1C))
+#define RCC_BDCR	((__REG) (RCC + 0x20))
+#define RCC_CSR		((__REG) (RCC + 0x24))
+
+/* Flash Memory Map */
+#define FLASH		((__REG_TYPE) 0x40022000)
+#define FLASH_ACR	((__REG) (FLASH + 0x00))
+
+/* GPIO Memory Map */
+#define GPIOA		((__REG_TYPE) 0x40010800)
+#define GPIOA_CRL	((__REG) (GPIOA + 0x00))
+#define GPIOA_CRH	((__REG) (GPIOA + 0x04))
+#define GPIOA_IDR	((__REG) (GPIOA + 0x08))
+#define GPIOA_ODR	((__REG) (GPIOA + 0x0C))
+#define GPIOA_BSRR	((__REG) (GPIOA + 0x10))
+#define GPIOA_BRR	((__REG) (GPIOA + 0x14))
+#define GPIOA_LCKR	((__REG) (GPIOA + 0x18))
+
+/* USART2 Memory Map */
+#define USART2		((__REG_TYPE) 0x40004400)
+#define USART2_SR	((__REG) (USART2 + 0x00))
+#define USART2_DR	((__REG) (USART2 + 0x04))
+#define USART2_BRR	((__REG) (USART2 + 0x08))
+#define USART2_CR1	((__REG) (USART2 + 0x0C))
+#define USART2_CR2	((__REG) (USART2 + 0x10))
+#define USART2_CR3	((__REG) (USART2 + 0x14))
+#define USART2_GTPR	((__REG) (USART2 + 0x18))
+
+/* SysTick Memory Map */
+#define SYSTICK		((__REG_TYPE) 0xE000E010)
+#define SYSTICK_CTRL	((__REG) (SYSTICK + 0x00))
+#define SYSTICK_LOAD	((__REG) (SYSTICK + 0x04))
+#define SYSTICK_VAL	((__REG) (SYSTICK + 0x08))
+#define SYSTICK_CALIB	((__REG) (SYSTICK + 0x0C))
+
+#endif

--- a/07-Threads/startup.c
+++ b/07-Threads/startup.c
@@ -1,0 +1,165 @@
+#include <stdint.h>
+#include "reg.h"
+
+/* Bit definition for RCC_CR register */
+#define RCC_CR_HSION	((uint32_t) 0x00000001)		/*!< Internal High Speed clock enable */
+#define RCC_CR_HSEON	((uint32_t) 0x00010000)		/*!< External High Speed clock enable */
+#define RCC_CR_HSERDY	((uint32_t) 0x00020000)		/*!< External High Speed clock ready flag */
+#define RCC_CR_CSSON	((uint32_t) 0x00080000)		/*!< Clock Security System enable */
+
+/* Bit definition for RCC_CFGR register */
+#define  RCC_CFGR_SW		((uint32_t) 0x00000003)	/*!< SW[1:0] bits (System clock Switch) */
+#define  RCC_CFGR_SW_HSE	((uint32_t) 0x00000001)	/*!< HSE selected as system clock */
+#define  RCC_CFGR_SWS		((uint32_t) 0x0000000C)	/*!< SWS[1:0] bits (System Clock Switch Status) */
+#define  RCC_CFGR_HPRE_DIV1	((uint32_t) 0x00000000)	/*!< SYSCLK not divided */
+#define  RCC_CFGR_PPRE1_DIV1	((uint32_t) 0x00000000)	/*!< HCLK not divided */
+#define  RCC_CFGR_PPRE2_DIV1	((uint32_t) 0x00000000)	/*!< HCLK not divided */
+
+/* Bit definition for FLASH_ACR register */
+#define FLASH_ACR_LATENCY	((uint8_t) 0x03)	/*!< LATENCY[2:0] bits (Latency) */
+#define FLASH_ACR_LATENCY_0	((uint8_t) 0x00)	/*!< Bit 0 */
+#define FLASH_ACR_PRFTBE	((uint8_t) 0x10)	/*!< Prefetch Buffer Enable */
+
+#define HSE_STARTUP_TIMEOUT	((uint16_t) 0x0500)	/*!< Time out for HSE start up */
+
+/* main program entry point */
+extern void main(void);
+
+/* start address for the initialization values of the .data section.
+ * defined in linker script */
+extern uint32_t _sidata;
+/* start address for the .data section. defined in linker script */
+extern uint32_t _sdata;
+/* end address for the .data section. defined in linker script */
+extern uint32_t _edata;
+/* start address for the .bss section. defined in linker script */
+extern uint32_t _sbss;
+/* end address for the .bss section. defined in linker script */
+extern uint32_t _ebss;
+/* end address for the stack. defined in linker script */
+extern uint32_t _estack;
+
+void rcc_clock_init(void);
+
+void reset_handler(void)
+{
+	/* Copy the data segment initializers from flash to SRAM */
+	uint32_t *idata_begin = &_sidata;
+	uint32_t *data_begin = &_sdata;
+	uint32_t *data_end = &_edata;
+	while (data_begin < data_end) *data_begin++ = *idata_begin++;
+
+	/* Zero fill the bss segment. */
+	uint32_t *bss_begin = &_sbss;
+	uint32_t *bss_end = &_ebss;
+	while (bss_begin < bss_end) *bss_begin++ = 0;
+
+	/* Clock system intitialization */
+	rcc_clock_init();
+
+	main();
+}
+
+void default_handler(void)
+{
+	while (1);
+}
+
+void nmi_handler(void) __attribute((weak, alias("default_handler")));
+void hardfault_handler(void) __attribute((weak, alias("default_handler")));
+void memmanage_handler(void) __attribute((weak, alias("default_handler")));
+void busfault_handler(void) __attribute((weak, alias("default_handler")));
+void usagefault_handler(void) __attribute((weak, alias("default_handler")));
+void svc_handler(void) __attribute((weak, alias("default_handler")));
+void pendsv_handler(void) __attribute((weak, alias("default_handler")));
+void systick_handler(void) __attribute((weak, alias("default_handler")));
+
+__attribute((section(".isr_vector")))
+uint32_t *isr_vectors[] = {
+	(uint32_t *) &_estack,			/* stack pointer */
+	(uint32_t *) reset_handler,		/* code entry point */
+	(uint32_t *) nmi_handler,		/* NMI handler */
+	(uint32_t *) hardfault_handler,		/* hard fault handler */
+	(uint32_t *) memmanage_handler,		/* mem manage handler */
+	(uint32_t *) busfault_handler,		/* bus fault handler */
+	(uint32_t *) usagefault_handler,	/* usage fault handler */
+	0,
+	0,
+	0,
+	0,
+	(uint32_t *) svc_handler,		/* svc handler */
+	0,
+	0,
+	(uint32_t *) pendsv_handler,		/* pendsv handler */
+	(uint32_t *) systick_handler		/* systick handler */
+};
+
+void rcc_clock_init(void)
+{
+	/* Reset the RCC clock configuration to the default reset state(for debug purpose) */
+	/* Set HSION bit */
+	*RCC_CR |= (uint32_t) 0x00000001;
+
+	/* Reset SW, HPRE, PPRE1, PPRE2, ADCPRE and MCO bits */
+	*RCC_CFGR &= (uint32_t) 0xF8FF0000;
+
+	/* Reset HSEON, CSSON and PLLON bits */
+	*RCC_CR &= (uint32_t) 0xFEF6FFFF;
+
+	/* Reset HSEBYP bit */
+	*RCC_CR &= (uint32_t) 0xFFFBFFFF;
+
+	/* Reset PLLSRC, PLLXTPRE, PLLMUL and USBPRE/OTGFSPRE bits */
+	*RCC_CFGR &= (uint32_t) 0xFF80FFFF;
+
+	/* Disable all interrupts and clear pending bits  */
+	*RCC_CIR = 0x009F0000;
+
+	/* Configure the System clock frequency, HCLK, PCLK2 and PCLK1 prescalers */
+	/* Configure the Flash Latency cycles and enable prefetch buffer */
+	volatile uint32_t StartUpCounter = 0, HSEStatus = 0;
+
+	/* SYSCLK, HCLK, PCLK2 and PCLK1 configuration ---------------------------*/
+	/* Enable HSE */
+	*RCC_CR |= ((uint32_t)RCC_CR_HSEON);
+
+	/* Wait till HSE is ready and if Time out is reached exit */
+	do {
+		HSEStatus = *RCC_CR & RCC_CR_HSERDY;
+		StartUpCounter++;
+	} while ((HSEStatus == 0) && (StartUpCounter != HSE_STARTUP_TIMEOUT));
+
+	if ((*RCC_CR & RCC_CR_HSERDY) != 0)
+		HSEStatus = (uint32_t) 0x01;
+	else
+		HSEStatus = (uint32_t) 0x00;
+
+	if (HSEStatus == (uint32_t) 0x01) {
+		/* Enable Prefetch Buffer */
+		*FLASH_ACR |= FLASH_ACR_PRFTBE;
+
+		/* Flash 0 wait state */
+		*FLASH_ACR &= (uint32_t)((uint32_t) ~FLASH_ACR_LATENCY);
+
+		*FLASH_ACR |= (uint32_t) FLASH_ACR_LATENCY_0;
+
+		/* HCLK = SYSCLK */
+		*RCC_CFGR |= (uint32_t) RCC_CFGR_HPRE_DIV1;
+
+		/* PCLK2 = HCLK */
+		*RCC_CFGR |= (uint32_t) RCC_CFGR_PPRE2_DIV1;
+
+		/* PCLK1 = HCLK */
+		*RCC_CFGR |= (uint32_t) RCC_CFGR_PPRE1_DIV1;
+
+		/* Select HSE as system clock source */
+		*RCC_CFGR &= (uint32_t)((uint32_t) ~(RCC_CFGR_SW));
+		*RCC_CFGR |= (uint32_t) RCC_CFGR_SW_HSE;
+
+		/* Wait till HSE is used as system clock source */
+		while ((*RCC_CFGR & (uint32_t) RCC_CFGR_SWS) != (uint32_t) 0x04);
+	} else {
+		/* If HSE fails to start-up, the application will have wrong clock
+		configuration. User can add here some code to deal with this error */
+	}
+}

--- a/07-Threads/threads.c
+++ b/07-Threads/threads.c
@@ -1,0 +1,132 @@
+#include <stdint.h>
+#include "threads.h"
+#include "os.h"
+#include "malloc.h"
+#include "reg.h"
+
+#define THREAD_PSP	0xFFFFFFFD
+
+/* Thread Control Block */
+typedef struct {
+	void *stack;
+	void *orig_stack;
+	uint8_t in_use;
+} tcb_t;
+
+static tcb_t tasks[MAX_TASKS];
+static int lastTask;
+static int first = 1;
+
+/* XXX: Without naked attribute, GCC will corrupt r7 which is used for stack
+ * pointer. If so, after restoring the tasks' context, we will get wrong stack
+ * pointer. Maybe here is a better solution instead of naked attribute?
+ */
+void __attribute__((naked)) pendsv_handler()
+{
+	/* Save the old task's context */
+	asm volatile("mrs   r0, psp\n"
+	             "stmdb r0!, {r4-r11, lr}\n"
+	             "mov   %0, r0\n"
+	             : "=r"(tasks[lastTask].stack));
+
+	/* Find a new task to run */
+	while (1) {
+		lastTask++;
+		if (lastTask == MAX_TASKS)
+			lastTask = 0;
+		if (tasks[lastTask].in_use) {
+			/* Restore the new task's context and jump to the task */
+			asm volatile("mov r0, %0\n"
+			             "ldmia r0!, {r4-r11, lr}\n"
+			             "msr psp, r0\n"
+			             "bx lr\n"
+			             : : "r"(tasks[lastTask].stack));
+		}
+	}
+}
+
+void systick_handler()
+{
+	*SCB_ICSR |= SCB_ICSR_PENDSVSET;
+}
+
+void thread_start()
+{
+	lastTask = 0;
+
+	/* Save kernel context */
+	asm volatile("mrs ip, psr\n"
+	             "push {r4-r11, ip, lr}\n");
+
+	/* Load user task's context and jump to the task */
+	asm volatile("mov r0, %0\n"
+	             "msr psp, r0\n"
+	             "mov r0, #3\n"
+	             "msr control, r0\n"
+	             "isb\n"
+	             "pop {r4-r11, lr}\n"
+	             "pop {r0}\n"
+	             "bx lr\n"
+	             : : "r"(tasks[lastTask].stack));
+}
+
+int thread_create(void (*run)(void *), void *userdata)
+{
+	/* Find a free thing */
+	int threadId = 0;
+	uint32_t *stack;
+
+	for (threadId = 0; threadId < MAX_TASKS; threadId++) {
+		if (tasks[threadId].in_use == 0)
+			break;
+	}
+
+	if (threadId == MAX_TASKS)
+		return -1;
+
+	/* Create the stack */
+	stack = (uint32_t *) malloc(STACK_SIZE * sizeof(uint32_t));
+	tasks[threadId].orig_stack = stack;
+	if (stack == 0)
+		return -1;
+
+	stack += STACK_SIZE - 32; /* End of stack, minus what we are about to push */
+	if (first) {
+		stack[8] = (unsigned int) run;
+		stack[9] = (unsigned int) userdata;
+		first = 0;
+	} else {
+		stack[8] = (unsigned int) THREAD_PSP;
+		stack[9] = (unsigned int) userdata;
+		stack[14] = (unsigned) &thread_self_terminal;
+		stack[15] = (unsigned int) run;
+		stack[16] = (unsigned int) 0x21000000; /* PSR Thumb bit */
+	}
+
+	// Create the control block
+	tasks[threadId].stack = stack;
+	tasks[threadId].in_use = 1;
+
+	return threadId;
+}
+
+void thread_kill(int thread_id)
+{
+	tasks[thread_id].in_use = 0;
+
+	/* Free the stack */
+	free(tasks[thread_id].orig_stack);
+}
+
+void thread_self_terminal()
+{
+	/* This will kill the stack.
+	 * For now, disable context switches to save ourselves.
+	 */
+	asm volatile("cpsid i\n");
+	thread_kill(lastTask);
+	asm volatile("cpsie i\n");
+
+	/* And now wait for death to kick in */
+	while (1);
+}

--- a/07-Threads/threads.h
+++ b/07-Threads/threads.h
@@ -1,0 +1,9 @@
+#ifndef __THREADS_H__
+#define __THREADS_H__
+
+void thread_start();
+int thread_create(void (*run)(void*), void* userdata);
+void thread_kill(int thread_id);
+void thread_self_terminal();
+
+#endif


### PR DESCRIPTION
Switch tasks in pendsv handler instead of switching back to kernel. This
method can reduce the number of context swtich.
e.g.
old: task1 -> kernel -> task2 = 2 context switch
new: task1 -> task2 = 1 context switch
